### PR TITLE
Update sonarwhal to webhint

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "grunt-contrib-yuidoc": "*",
         "grunt-jscs": "*",
         "grunt-run-grunt": "*",
+        "hint": "*",
         "http-server": "*",
         "copyfiles": "*",
         "matchdep": "*",
@@ -46,7 +47,6 @@
         "strip-bom": "*",
         "workbox-cli": "*",
         "workbox-sw": "^2.1.1",
-        "lighthouse": "*",
-        "sonarwhal": "*"
+        "lighthouse": "*"
     }
 }


### PR DESCRIPTION
sonarwhal was renamed to webhint. This PR updates any reference to the new package.

Ref: https://medium.com/webhint/webhint-a-hinting-engine-for-the-web-ef0d3fa32ea9